### PR TITLE
Fix example configuration and variable names

### DIFF
--- a/website/docs/r/custom_resource.html.markdown
+++ b/website/docs/r/custom_resource.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Sample resource in the Terraform provider custom.
 
-Following files will be created in directory defined by `${TF_CUSTOM_DIR}` or `${TF_CUSTOM_DIR_ABS}`:
+Following files will be created in directory defined by `${TF_EXTERNAL_DIR}` or `${TF_EXTERNAL_DIR_ABS}`:
 - `provider_input` - (read-only) - inputs passed down from `provider` configuration
 - `input` - (read-only) - inputs passed down from the resource's attribute, see arguments reference
 - `input_sensitive` - (read-only) - inputs passed down from the resource's attribute, see arguments reference
@@ -32,29 +32,29 @@ locals {
   }
 
   cmd_update() {
-	file_name="$(cat "$TF_CUSTOM_DIR/input" | tee "$TF_CUSTOM_DIR/id" "$TF_CUSTOM_DIR/output")"
-	cat "$TF_CUSTOM_DIR/state" | tee "$TF_CUSTOM_DIR/state" > "$file_name"
+	file_name="$(cat "$TF_EXTERNAL_DIR/input" | tee "$TF_EXTERNAL_DIR/id" "$TF_EXTERNAL_DIR/output")"
+	cat "$TF_EXTERNAL_DIR/state" | tee "$TF_EXTERNAL_DIR/state" > "$file_name"
   }
 
   cmd_read() {
-	file_name="$(cat "$TF_CUSTOM_DIR/input")"
+	file_name="$(cat "$TF_EXTERNAL_DIR/input")"
 	cat "$file_name"
-	cat "$TF_CUSTOM_DIR/state"
-	echo -n "$file_name" > "$TF_CUSTOM_DIR/output"
-	cat "$file_name" > "$TF_CUSTOM_DIR/state"
-  }
-  
-  cmd_delete() {
-	rm "$(cat "$TF_CUSTOM_DIR/input")"
+	cat "$TF_EXTERNAL_DIR/state"
+	echo -n "$file_name" > "$TF_EXTERNAL_DIR/output"
+	cat "$file_name" > "$TF_EXTERNAL_DIR/state"
   }
 
-  main "$@"
+  cmd_delete() {
+	rm "$(cat "$TF_EXTERNAL_DIR/input")"
+  }
+
+  main "$0"
   EOT
 
-  program = ["sh", "-c", local.script, "command_string"]
+  program = ["bash", "-c", local.script]
 }
 
-resource "custom_resource" "foo" {
+resource "external" "foo" {
   input = "/tmp/terraform-provider-custom_resource_test"
   state = "qwe"
 
@@ -69,12 +69,12 @@ resource "custom_resource" "foo" {
 
 The following arguments are supported:
 
-* `program_create` - (Optional) program to run on `create` operation, runs `program_update` instead if not provided. Be sure to write to `${TF_CUSTOM_DIR}/id`.
-* `program_read` - program to run on `read` operation. It should update `${TF_CUSTOM_DIR}/state` to reflect world's state. Emptying `${TF_CUSTOM_DIR}/id` will inform Terraform that resource does not exist anymore.
-* `program_update` - program to run on `update` (and optionally `create`) operations.  It should update `${TF_CUSTOM_DIR}/state` to reflect world's state.
+* `program_create` - (Optional) program to run on `create` operation, runs `program_update` instead if not provided. Be sure to write to `${TF_EXTERNAL_DIR}/id`.
+* `program_read` - program to run on `read` operation. It should update `${TF_EXTERNAL_DIR}/state` to reflect world's state. Emptying `${TF_EXTERNAL_DIR}/id` will inform Terraform that resource does not exist anymore.
+* `program_update` - program to run on `update` (and optionally `create`) operations.  It should update `${TF_EXTERNAL_DIR}/state` to reflect world's state.
 * `program_delete` - program to run on `destroy` operation.
-* `state` - (`${TF_CUSTOM_DIR}/state` read-write, `${TF_CUSTOM_DIR}/old_state` read-only) managed parts of resource's real state, it should be written to (during course of `create`, `read` and `update` commands) to reflect current state of the world.
-* `input` - (`${TF_CUSTOM_DIR}/input` read-only) unmanaged/to-be-interpolated parts of resource's desired state
-* `input_sensitive` - (`${TF_CUSTOM_DIR}/input_sensitive` read-only) same as `input`, but the content won't be printed during planning.
-* `output` - (`${TF_CUSTOM_DIR}/output` write-only) additional (relative to `state` attribute) data the resource is providing.
-* `output_sensitive` - (`${TF_CUSTOM_DIR}/output_sensitive` write-only) same as `output`, but content won't be printed during planning.
+* `state` - (`${TF_EXTERNAL_DIR}/state` read-write, `${TF_EXTERNAL_DIR}/old_state` read-only) managed parts of resource's real state, it should be written to (during course of `create`, `read` and `update` commands) to reflect current state of the world.
+* `input` - (`${TF_EXTERNAL_DIR}/input` read-only) unmanaged/to-be-interpolated parts of resource's desired state
+* `input_sensitive` - (`${TF_EXTERNAL_DIR}/input_sensitive` read-only) same as `input`, but the content won't be printed during planning.
+* `output` - (`${TF_EXTERNAL_DIR}/output` write-only) additional (relative to `state` attribute) data the resource is providing.
+* `output_sensitive` - (`${TF_EXTERNAL_DIR}/output_sensitive` write-only) same as `output`, but content won't be printed during planning.


### PR DESCRIPTION
These changes were required for provided example to work.

Documentation:

- `TF_CUSTOM_DIR` → `TF_EXTERNAL_DIR`

Script:

- `TF_CUSTOM_DIR` → `TF_EXTERNAL_DIR`
- `sh` → `bash` (`set -xeuo pipefail` doesn't work in `sh`)
- `$@` → `$0` (for some reason `$@` is not populated when running shell with `-c` option)

Configuration:

- `custom_resource` → `external`
- remove `command_string`